### PR TITLE
修复 mysql 事务使用不当引起的mysql连接死锁问题。

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -5,6 +5,7 @@ mock('mysql', {
   createPool: () => {
     return {
       _allConnections: [],
+      _connectionQueue: [],
       getConnection(callback) {
         callback(null, {
           query(sqlOptions, callback) {
@@ -24,6 +25,7 @@ mock('mysql', {
           }
         });
       },
+      releaseConnection(connection) {},
       on() {
 
       },

--- a/test/index.js
+++ b/test/index.js
@@ -4,6 +4,7 @@ const mock = require('mock-require');
 mock('mysql', {
   createPool: () => {
     return {
+      _allConnections: [],
       getConnection(callback) {
         callback(null, {
           query(sqlOptions, callback) {


### PR DESCRIPTION
修复 mysql 事务使用不当引起的mysql连接死锁问题。

在日常使用中发现，如果在事务中有多个连接，会引起死锁，导致整个thinkjs应用无法再操作任何数据库。如果用户未开启debug，也不会发现这个问题，排查会十分痛苦。
示例代码：

```
async indexAction() {
    const model = this.model('person');
    try {
      await model.startTrans();
      const id = await model.add({ name: `liming${Date.now()}` });
      await this.model('project').add({ name: `test Trans${Date.now()}` });
      await model.commit();
      return this.display();
    } catch (e) {
      await model.rollback();
      return this.fail(e.message)
    }
  }
```
bug原因：
在npm的mysql包中发现，默认的`config.connectionLimit`为1，而在`Pool.prototype.getConnection`中，如果发现已有连接数不小于这个限制，会进入`this._enqueueCallback(cb);`
在这个callback中，只会`emit enqueue`。
在thinkjs中，触发`enqueue`也只会debug出一条信息。

修复方式：
在事务开启和关闭的时候加入一个变量来记录，在`getConnection`的时候，判断当前是否在事务中，并且是否已经存在连接，并且当前队列已经有连接在排队了。这时候，清除mysql连接，抛出正确的异常。

TODO：
目前，自测了几个小场景，存在的问题如下：
1. 错误信息不能正确抛出，原因是因为think-model-mysql中query函数后的catch写的问题，具体还在看。